### PR TITLE
Fix to stop import pdfjsWorker from "pdfjs-dist/build/pdf.worker.entry" from breaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-pdf",
   "svelte": "src/index.js",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "svelte-pdf provides a component for rendering PDF documents using PDF.js",
   "main": "src/index.js",
   "type": "module",
@@ -26,8 +26,8 @@
     "svelte": "^3.0.0"
   },
   "dependencies": {
-    "file-saver": "^2.0.2",
-    "pdfjs-dist": "^2.5.207"
+    "file-saver": "^2.0.5",
+    "pdfjs-dist": "^2.13.216"
   },
   "repository": {
     "type": "git",

--- a/src/PdfViewer.svelte
+++ b/src/PdfViewer.svelte
@@ -1,7 +1,7 @@
 <script>
   import { onDestroy, tick } from "svelte";
   import * as pdfjs from "pdfjs-dist";
-  import pdfjsWorker from "pdfjs-dist/build/pdf.worker.entry";
+  import workerSrc from "pdfjs-dist/build/pdf.worker.min.js?url";
   import FileSaver from "file-saver";
   import { onPrint, calcRT, getPageText } from "./utils/Helper.svelte";
   import Tooltip from "./utils/Tooltip.svelte";
@@ -14,7 +14,9 @@
   export let showBorder = true; //boolean
   export let totalPage = 0;
 
-  pdfjs.GlobalWorkerOptions.workerSrc = pdfjsWorker;
+  if (pdfjs.GlobalWorkerOptions) {
+    pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
+  }
 
   let canvas;
   let page_num = 0;
@@ -37,10 +39,10 @@
   const minScale = 1.0;
   const maxScale = 2.3;
 
-  const renderPage = num => {
+  const renderPage = (num) => {
     pageRendering = true;
     // Using promise to fetch the page
-    pdfDoc.getPage(num).then(function(page) {
+    pdfDoc.getPage(num).then(function (page) {
       let viewport = page.getViewport({ scale: scale, rotation: rotation });
       const canvasContext = canvas.getContext("2d");
       canvas.height = viewport.height;
@@ -49,12 +51,12 @@
       // Render PDF page into canvas context
       let renderContext = {
         canvasContext,
-        viewport
+        viewport,
       };
       let renderTask = page.render(renderContext);
 
       // Wait for rendering to finish
-      renderTask.promise.then(function() {
+      renderTask.promise.then(function () {
         pageRendering = false;
         if (pageNumPending !== null) {
           // New page rendering is pending
@@ -77,7 +79,7 @@
     showButtons === true ? (page_num.textContent = num) : null;
   };
 
-  const queueRenderPage = num => {
+  const queueRenderPage = (num) => {
     if (pageRendering) {
       pageNumPending = num;
     } else {
@@ -125,7 +127,7 @@
     }
   };
 
-  const printPdf = url => {
+  const printPdf = (url) => {
     onPrint(url);
   };
 
@@ -150,7 +152,7 @@
   const initialLoad = async () => {
     let loadingTask = pdfjs.getDocument({ url, password });
     loadingTask.promise
-      .then(async function(pdfDoc_) {
+      .then(async function (pdfDoc_) {
         pdfDoc = pdfDoc_;
         passwordError = false;
         await tick();
@@ -160,7 +162,7 @@
         if (showButtons === true) {
           for (let number = 1; number <= totalPage; number++) {
             // Extract the text
-            getPageText(number, pdfDoc).then(function(textPage) {
+            getPageText(number, pdfDoc).then(function (textPage) {
               // Show the text of the page in the console
               pdfContent = pdfContent.concat(textPage);
               readingTime = calcRT(pdfContent);
@@ -169,7 +171,7 @@
         }
         isInitialised = true;
       })
-      .catch(function(error) {
+      .catch(function (error) {
         passwordError = true;
         passwordMessage = error.message;
         if (passwordMessage === "Failed to fetch") {
@@ -201,7 +203,7 @@
     }
   };
   //Download pdf function
-  const downloadPdf = fileURL => {
+  const downloadPdf = (fileURL) => {
     let fileName = fileURL.substring(fileURL.lastIndexOf("/") + 1);
     FileSaver.saveAs(fileURL, fileName);
   };
@@ -210,7 +212,258 @@
     clearInterval(interval);
     clearInterval(secondInterval);
   });
+
+  let pageWidth;
+  let pageHeight;
 </script>
+
+<svelte:window bind:innerWidth={pageWidth} bind:innerHeight={pageHeight} />
+<div class="parent">
+  <div class={showBorder === true ? "control" : "null"}>
+    {#if passwordError === true}
+      <div class="password-viewer">
+        <p>This document requires a password to open:</p>
+        <p class="password-message">{passwordMessage}</p>
+        <div class="password-container">
+          <input type="password" class="password-input" bind:value={password} />
+          <button on:click={onPasswordSubmit} class="password-button">
+            Submit
+          </button>
+        </div>
+      </div>
+    {:else if showButtons === true}
+      <div class="control-start">
+        <div class="line">
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control {pageNum <= 1 ? 'disabled' : null}"
+              on:click={() => onPrevPage()}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <polygon
+                  points="3.828 9 9.899 2.929 8.485 1.515 0 10 .707 10.707 8.485
+                  18.485 9.899 17.071 3.828 11 20 11 20 9 3.828 9"
+                />
+              </svg>
+            </span>
+            Prevoius
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control {pageNum >= totalPage ? 'disabled' : null}"
+              on:click={() => onNextPage()}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <polygon
+                  points="16.172 9 10.101 2.929 11.515 1.515 20 10 19.293 10.707
+                  11.515 18.485 10.101 17.071 16.172 11 0 11 0 9"
+                />
+              </svg>
+            </span>
+            Next
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control {scale >= maxScale ? 'disabled' : null}"
+              on:click={() => onZoomIn()}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
+                  1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zM7
+                  7V5h2v2h2v2H9v2H7V9H5V7h2z"
+                />
+              </svg>
+            </span>
+            Zoom In
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control {scale <= minScale ? 'disabled' : null}"
+              on:click={() => onZoomOut()}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  fill-rule="evenodd"
+                  d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
+                  1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zM5
+                  7h6v2H5V7z"
+                />
+              </svg>
+            </span>
+            Zoom Out
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control"
+              on:click={() => printPdf(url)}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  d="M4 16H0V6h20v10h-4v4H4v-4zm2-4v6h8v-6H6zM4 0h12v5H4V0zM2
+                  8v2h2V8H2zm4 0v2h2V8H6z"
+                />
+              </svg>
+            </span>
+            Print
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control"
+              on:click={() => antiClockwiseRotate()}
+            >
+              <svg
+                class="icon rot-icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
+                  1.42zM12 10h8l-4 4-4-4z"
+                />
+              </svg>
+            </span>
+            Anti-Clockwise
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control"
+              on:click={() => clockwiseRotate()}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path
+                  d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
+                  1.42zM12 10h8l-4 4-4-4z"
+                />
+              </svg>
+            </span>
+            Clockwise
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="button-control"
+              on:click={() => downloadPdf(url)}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
+              </svg>
+            </span>
+            Download
+          </Tooltip>
+          <Tooltip>
+            <span
+              slot="activator"
+              class="page-info button-control"
+              on:click={() => onPageTurn()}
+            >
+              <svg
+                class="icon"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+              >
+                {#if autoFlip === true}
+                  <path d="M4 18h12V6h-4V2H4v16zm-2 1V0h12l4 4v16H2v-1z" />
+                {:else}
+                  <path
+                    d="M9.896,3.838L0.792,1.562v14.794l9.104,2.276L19,16.356V1.562L9.896,3.838z
+                    M9.327,17.332L1.93,15.219V3.27 l7.397,1.585V17.332z
+                    M17.862,15.219l-7.397,2.113V4.855l7.397-1.585V15.219z"
+                  />
+                {/if}
+              </svg>
+            </span>
+            {autoFlip === true ? seconds : "Auto Turn Page"}
+          </Tooltip>
+          <span class="page-info">
+            <svg
+              class="icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+            >
+              <path
+                d="M16.32 7.1A8 8 0 1 1 9 4.06V2h2v2.06c1.46.18 2.8.76 3.9
+                1.62l1.46-1.46 1.42 1.42-1.46 1.45zM10 18a6 6 0 1 0 0-12 6 6 0 0
+                0 0 12zM7 0h6v2H7V0zm5.12 8.46l1.42 1.42L10 13.4 8.59
+                12l3.53-3.54z"
+              />
+            </svg>
+            <span class="text">{readingTime} min read</span>
+          </span>
+          <span class="page-info">
+            <svg
+              class="icon"
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+            >
+              <path
+                d="M16 2h4v15a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V0h16v2zm0 2v13a1 1 0
+                0 0 1 1 1 1 0 0 0 1-1V4h-2zM2 2v15a1 1 0 0 0 1 1h11.17a2.98 2.98
+                0 0 1-.17-1V2H2zm2 8h8v2H4v-2zm0 4h8v2H4v-2zM4 4h8v4H4V4z"
+              />
+            </svg>
+            <div class="text">
+              Page :
+              <span bind:this={page_num} />
+              /
+              <span bind:this={pageCount} />
+            </div>
+          </span>
+        </div>
+        <div class={showBorder === true ? "viewer" : "null"}>
+          <canvas bind:this={canvas} width={pageWidth} height={pageHeight} />
+        </div>
+      </div>
+    {:else}
+      <div class={showBorder === true ? "viewer" : "null"}>
+        <canvas bind:this={canvas} />
+        <!-- width={window.innerWidth} -->
+        <!-- height={window.innerHeight}  -->
+      </div>
+    {/if}
+  </div>
+  <button id="topBtn" on:click={() => window.scrollTo(0, 0)}>
+    <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
+      <path d="M7 10v8h6v-8h5l-8-8-8 8h5z" />
+    </svg>
+  </button>
+</div>
 
 <style>
   :global(html) {
@@ -326,7 +579,7 @@
     cursor: default;
   }
   .rot-icon {
-    transform : scaleX(-1)
+    transform: scaleX(-1);
   }
   #topBtn {
     position: fixed;
@@ -467,223 +720,3 @@
     }
   }
 </style>
-
-<div class="parent">
-  <div class={showBorder === true ? 'control' : 'null'}>
-    {#if passwordError === true}
-      <div class="password-viewer">
-        <p>This document requires a password to open:</p>
-        <p class="password-message">{passwordMessage}</p>
-        <div class="password-container">
-          <input type="password" class="password-input" bind:value={password} />
-          <button on:click={onPasswordSubmit} class="password-button">
-            Submit
-          </button>
-        </div>
-      </div>
-    {:else if showButtons === true}
-      <div class="control-start">
-        <div class="line">
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {pageNum <= 1 ? 'disabled' : null}"
-              on:click={() => onPrevPage()}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <polygon
-                  points="3.828 9 9.899 2.929 8.485 1.515 0 10 .707 10.707 8.485
-                  18.485 9.899 17.071 3.828 11 20 11 20 9 3.828 9" />
-              </svg>
-            </span>
-            Prevoius
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {pageNum >= totalPage ? 'disabled' : null}"
-              on:click={() => onNextPage()}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <polygon
-                  points="16.172 9 10.101 2.929 11.515 1.515 20 10 19.293 10.707
-                  11.515 18.485 10.101 17.071 16.172 11 0 11 0 9" />
-              </svg>
-            </span>
-            Next
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {scale >= maxScale ? 'disabled' : null}"
-              on:click={() => onZoomIn()}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <path
-                  fill-rule="evenodd"
-                  d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
-                  1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zM7
-                  7V5h2v2h2v2H9v2H7V9H5V7h2z" />
-              </svg>
-            </span>
-            Zoom In
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {scale <= minScale ? 'disabled' : null}"
-              on:click={() => onZoomOut()}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <path
-                  fill-rule="evenodd"
-                  d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
-                  1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zM5
-                  7h6v2H5V7z" />
-              </svg>
-            </span>
-            Zoom Out
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => printPdf(url)}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <path
-                  d="M4 16H0V6h20v10h-4v4H4v-4zm2-4v6h8v-6H6zM4 0h12v5H4V0zM2
-                  8v2h2V8H2zm4 0v2h2V8H6z" />
-              </svg>
-            </span>
-            Print
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => antiClockwiseRotate()}>
-              <svg
-                class="icon rot-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <path
-                  d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
-                  1.42zM12 10h8l-4 4-4-4z" />
-              </svg>
-            </span>
-            Anti-Clockwise
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => clockwiseRotate()}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <path
-                  d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
-                  1.42zM12 10h8l-4 4-4-4z" />
-              </svg>
-            </span>
-            Clockwise
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => downloadPdf(url)}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
-              </svg>
-            </span>
-            Download
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="page-info button-control"
-              on:click={() => onPageTurn()}>
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20">
-                {#if autoFlip === true}
-                  <path d="M4 18h12V6h-4V2H4v16zm-2 1V0h12l4 4v16H2v-1z" />
-                {:else}
-                  <path
-                    d="M9.896,3.838L0.792,1.562v14.794l9.104,2.276L19,16.356V1.562L9.896,3.838z
-                    M9.327,17.332L1.93,15.219V3.27 l7.397,1.585V17.332z
-                    M17.862,15.219l-7.397,2.113V4.855l7.397-1.585V15.219z" />
-                {/if}
-              </svg>
-            </span>
-            {autoFlip === true ? seconds : 'Auto Turn Page'}
-          </Tooltip>
-          <span class="page-info">
-            <svg
-              class="icon"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20">
-              <path
-                d="M16.32 7.1A8 8 0 1 1 9 4.06V2h2v2.06c1.46.18 2.8.76 3.9
-                1.62l1.46-1.46 1.42 1.42-1.46 1.45zM10 18a6 6 0 1 0 0-12 6 6 0 0
-                0 0 12zM7 0h6v2H7V0zm5.12 8.46l1.42 1.42L10 13.4 8.59
-                12l3.53-3.54z" />
-            </svg>
-            <span class="text">{readingTime} min read</span>
-          </span>
-          <span class="page-info">
-            <svg
-              class="icon"
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20">
-              <path
-                d="M16 2h4v15a3 3 0 0 1-3 3H3a3 3 0 0 1-3-3V0h16v2zm0 2v13a1 1 0
-                0 0 1 1 1 1 0 0 0 1-1V4h-2zM2 2v15a1 1 0 0 0 1 1h11.17a2.98 2.98
-                0 0 1-.17-1V2H2zm2 8h8v2H4v-2zm0 4h8v2H4v-2zM4 4h8v4H4V4z" />
-            </svg>
-            <div class="text">
-              Page :
-              <span bind:this={page_num} />
-              /
-              <span bind:this={pageCount} />
-            </div>
-          </span>
-        </div>
-        <div class={showBorder === true ? 'viewer' : 'null'}>
-          <canvas
-            bind:this={canvas}
-            width={window.innerWidth}
-            height={window.innerHeight} />
-        </div>
-      </div>
-    {:else}
-      <div class={showBorder === true ? 'viewer' : 'null'}>
-        <canvas bind:this={canvas} />
-        <!-- width={window.innerWidth} -->
-        <!-- height={window.innerHeight}  -->
-      </div>
-    {/if}
-  </div>
-  <button id="topBtn" on:click={() => window.scrollTo(0,0)}>
-      <svg class="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20">
-        <path d="M7 10v8h6v-8h5l-8-8-8 8h5z" />
-      </svg>
-  </button>
-</div>


### PR DESCRIPTION
Hi @vinodnimbalkar ,
I kept hitting an error in sveltekit about the import location. This fixes it.

Bind 
```  let pageWidth;
  let pageHeight;
</script>

<svelte:window bind:innerWidth={pageWidth} bind:innerHeight={pageHeight} />```
to prevent page from breaking with the previous method when of the page was being served with SSR
```    <canvas
            bind:this={canvas}
            width={window.innerWidth}
            height={window.innerHeight} />```