### PR TITLE
Add button render replacements via slots and list of button groups to be displayed

### DIFF
--- a/src/PdfViewer.svelte
+++ b/src/PdfViewer.svelte
@@ -10,7 +10,16 @@
   export let scale = 1.8;
   export let pageNum = 1; //must be number
   export let flipTime = 120; //by default 2 minute, value in seconds
-  export let showButtons = true; //boolean
+  export let showMenuElements = [
+    "navigation",
+    "zoom",
+    "print",
+    "rotate",
+    "download",
+    "autoflip",
+    "timeInfo",
+    "pageInfo",
+  ]; //array
   export let showBorder = true; //boolean
   export let totalPage = 0;
 
@@ -18,6 +27,7 @@
     pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
   }
 
+  let showMenu = showMenuElements && showMenuElements.length > 0;
   let canvas;
   let page_num = 0;
   let pageCount = 0;
@@ -76,7 +86,7 @@
     });
 
     // Update page counters
-    showButtons === true ? (page_num.textContent = num) : null;
+    showMenu ? (page_num.textContent = num) : null;
   };
 
   const queueRenderPage = (num) => {
@@ -157,9 +167,9 @@
         passwordError = false;
         await tick();
 
-        showButtons === true ? (pageCount.textContent = pdfDoc.numPages) : null;
+        showMenu ? (pageCount.textContent = pdfDoc.numPages) : null;
         totalPage = pdfDoc.numPages;
-        if (showButtons === true) {
+        if (showMenu) {
           for (let number = 1; number <= totalPage; number++) {
             // Extract the text
             getPageText(number, pdfDoc).then(function (textPage) {
@@ -218,6 +228,7 @@
 </script>
 
 <svelte:window bind:innerWidth={pageWidth} bind:innerHeight={pageHeight} />
+
 <div class="parent">
   <div class={showBorder === true ? "control" : "null"}>
     {#if passwordError === true}
@@ -231,187 +242,276 @@
           </button>
         </div>
       </div>
-    {:else if showButtons === true}
+    {:else if showMenu === true}
       <div class="control-start">
         <div class="line">
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {pageNum <= 1 ? 'disabled' : null}"
-              on:click={() => onPrevPage()}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <polygon
-                  points="3.828 9 9.899 2.929 8.485 1.515 0 10 .707 10.707 8.485
+          {#if showMenuElements.includes("navigation")}
+            {#if $$slots.prevButton}
+              <slot
+                name="prevButton"
+                clickAction={() => onPrevPage()}
+                disabled={pageNum <= 1}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control {pageNum <= 1 ? 'disabled' : null}"
+                  on:click={() => onPrevPage()}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <polygon
+                      points="3.828 9 9.899 2.929 8.485 1.515 0 10 .707 10.707 8.485
                   18.485 9.899 17.071 3.828 11 20 11 20 9 3.828 9"
-                />
-              </svg>
-            </span>
-            Prevoius
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {pageNum >= totalPage ? 'disabled' : null}"
-              on:click={() => onNextPage()}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <polygon
-                  points="16.172 9 10.101 2.929 11.515 1.515 20 10 19.293 10.707
+                    />
+                  </svg>
+                </span>
+                Prevoius
+              </Tooltip>
+            {/if}
+
+            {#if $$slots.nextButton}
+              <slot
+                name="nextButton"
+                clickAction={() => onNextPage()}
+                disabled={pageNum >= totalPage}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control {pageNum >= totalPage
+                    ? 'disabled'
+                    : null}"
+                  on:click={() => onNextPage()}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <polygon
+                      points="16.172 9 10.101 2.929 11.515 1.515 20 10 19.293 10.707
                   11.515 18.485 10.101 17.071 16.172 11 0 11 0 9"
-                />
-              </svg>
-            </span>
-            Next
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {scale >= maxScale ? 'disabled' : null}"
-              on:click={() => onZoomIn()}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
+                    />
+                  </svg>
+                </span>
+                Next
+              </Tooltip>
+            {/if}
+          {/if}
+
+          {#if showMenuElements.includes("zoom")}
+            {#if $$slots.zoomInButton}
+              <slot
+                name="zoomInButton"
+                clickAction={() => onZoomIn()}
+                disabled={scale >= maxScale}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control {scale >= maxScale ? 'disabled' : null}"
+                  on:click={() => onZoomIn()}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
                   1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zM7
                   7V5h2v2h2v2H9v2H7V9H5V7h2z"
-                />
-              </svg>
-            </span>
-            Zoom In
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control {scale <= minScale ? 'disabled' : null}"
-              on:click={() => onZoomOut()}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
+                    />
+                  </svg>
+                </span>
+                Zoom In
+              </Tooltip>
+            {/if}
+
+            {#if $$slots.zoomOutButton}
+              <slot
+                name="zoomOutButton"
+                clickAction={() => onZoomOut()}
+                disabled={scale <= minScale}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control {scale <= minScale ? 'disabled' : null}"
+                  on:click={() => onZoomOut()}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      fill-rule="evenodd"
+                      d="M12.9 14.32a8 8 0 1 1 1.41-1.41l5.35 5.33-1.42
                   1.42-5.33-5.34zM8 14A6 6 0 1 0 8 2a6 6 0 0 0 0 12zM5
                   7h6v2H5V7z"
-                />
-              </svg>
-            </span>
-            Zoom Out
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => printPdf(url)}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  d="M4 16H0V6h20v10h-4v4H4v-4zm2-4v6h8v-6H6zM4 0h12v5H4V0zM2
+                    />
+                  </svg>
+                </span>
+                Zoom Out
+              </Tooltip>
+            {/if}
+          {/if}
+
+          {#if showMenuElements.includes("print")}
+            {#if $$slots.printButton}
+              <slot name="printButton" clickAction={() => printPdf(url)} />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control"
+                  on:click={() => printPdf(url)}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      d="M4 16H0V6h20v10h-4v4H4v-4zm2-4v6h8v-6H6zM4 0h12v5H4V0zM2
                   8v2h2V8H2zm4 0v2h2V8H6z"
-                />
-              </svg>
-            </span>
-            Print
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => antiClockwiseRotate()}
-            >
-              <svg
-                class="icon rot-icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
+                    />
+                  </svg>
+                </span>
+                Print
+              </Tooltip>
+            {/if}
+          {/if}
+
+          {#if showMenuElements.includes("rotate")}
+            {#if $$slots.antiClockwiseRotateButton}
+              <slot
+                name="antiClockwiseRotateButton"
+                clickAction={() => antiClockwiseRotate()}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control"
+                  on:click={() => antiClockwiseRotate()}
+                >
+                  <svg
+                    class="icon rot-icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
                   1.42zM12 10h8l-4 4-4-4z"
-                />
-              </svg>
-            </span>
-            Anti-Clockwise
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => clockwiseRotate()}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path
-                  d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
+                    />
+                  </svg>
+                </span>
+                Anti-Clockwise
+              </Tooltip>
+            {/if}
+
+            {#if $$slots.clockwiseRotateButton}
+              <slot
+                name="clockwiseRotateButton"
+                clickAction={() => clockwiseRotate()}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control"
+                  on:click={() => clockwiseRotate()}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path
+                      d="M14.66 15.66A8 8 0 1 1 17 10h-2a6 6 0 1 0-1.76 4.24l1.42
                   1.42zM12 10h8l-4 4-4-4z"
-                />
-              </svg>
-            </span>
-            Clockwise
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="button-control"
-              on:click={() => downloadPdf(url)}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
-              </svg>
-            </span>
-            Download
-          </Tooltip>
-          <Tooltip>
-            <span
-              slot="activator"
-              class="page-info button-control"
-              on:click={() => onPageTurn()}
-            >
-              <svg
-                class="icon"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 20 20"
-              >
-                {#if autoFlip === true}
-                  <path d="M4 18h12V6h-4V2H4v16zm-2 1V0h12l4 4v16H2v-1z" />
-                {:else}
-                  <path
-                    d="M9.896,3.838L0.792,1.562v14.794l9.104,2.276L19,16.356V1.562L9.896,3.838z
+                    />
+                  </svg>
+                </span>
+                Clockwise
+              </Tooltip>
+            {/if}
+          {/if}
+
+          {#if showMenuElements.includes("download")}
+            {#if $$slots.downloadButton}
+              <slot
+                name="downloadButton"
+                clickAction={() => downloadPdf(url)}
+              />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="button-control"
+                  on:click={() => downloadPdf(url)}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    <path d="M13 8V2H7v6H2l8 8 8-8h-5zM0 18h20v2H0v-2z" />
+                  </svg>
+                </span>
+                Download
+              </Tooltip>
+            {/if}
+          {/if}
+
+          {#if showMenuElements.includes("autoPageTurn")}
+            {#if $$slots.pageTurnButton}
+              <slot name="pageTurnButton" clickAction={() => onPageTurn()} />
+            {:else}
+              <Tooltip>
+                <span
+                  slot="activator"
+                  class="page-info button-control"
+                  on:click={() => onPageTurn()}
+                >
+                  <svg
+                    class="icon"
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                  >
+                    {#if autoFlip === true}
+                      <path d="M4 18h12V6h-4V2H4v16zm-2 1V0h12l4 4v16H2v-1z" />
+                    {:else}
+                      <path
+                        d="M9.896,3.838L0.792,1.562v14.794l9.104,2.276L19,16.356V1.562L9.896,3.838z
                     M9.327,17.332L1.93,15.219V3.27 l7.397,1.585V17.332z
                     M17.862,15.219l-7.397,2.113V4.855l7.397-1.585V15.219z"
-                  />
-                {/if}
-              </svg>
-            </span>
-            {autoFlip === true ? seconds : "Auto Turn Page"}
-          </Tooltip>
-          <span class="page-info">
+                      />
+                    {/if}
+                  </svg>
+                </span>
+                {autoFlip === true ? seconds : "Auto Turn Page"}
+              </Tooltip>
+            {/if}
+          {/if}
+
+          <span
+            class="page-info"
+            style={showMenuElements.includes("timeInfo")
+              ? ""
+              : "display: none;"}
+          >
             <svg
               class="icon"
               xmlns="http://www.w3.org/2000/svg"
@@ -426,7 +526,13 @@
             </svg>
             <span class="text">{readingTime} min read</span>
           </span>
-          <span class="page-info">
+
+          <span
+            class="page-info"
+            style={showMenuElements.includes("pageInfo")
+              ? ""
+              : "display: none;"}
+          >
             <svg
               class="icon"
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Hi, I've done some small updates to allow displaying only desired buttons, and a way to replace button render via slot ('action' and 'disabled' props are passed to parent component). 

You can replace a button rendering with something like this:

```svelte
      <div slot="nextButton" let:clickAction let:disabled class="ml-1">
        <Button type={ButtonType.Tertiary} on:click={clickAction} {disabled}>
          <Fa icon={faArrowRight} />
        </Button>
      </div>
```

New showMenuElements prop:

```javascript
  export let showMenuElements = [
    "navigation",
    "zoom",
    "print",
    "rotate",
    "download",
    "autoflip",
    "timeInfo",
    "pageInfo",
  ];
```

New button slots are `prevButton`, `nextButton`, `zoomInButton`, `zoomOutButton`, `printButton`, `antiClockwiseRotateButton`, `clockwiseRotateButton`, `downloadButton`, `pageTurnButton`.

Thank you!